### PR TITLE
Refactor twig rules to implement PHPStan\Rules\Rule

### DIFF
--- a/packages/reveal-twig/src/Rules/NoTwigMissingVariableRule.php
+++ b/packages/reveal-twig/src/Rules/NoTwigMissingVariableRule.php
@@ -7,17 +7,18 @@ namespace Reveal\RevealTwig\Rules;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
 use Reveal\RevealTwig\NodeAnalyzer\SymfonyRenderWithParametersMatcher;
 use Reveal\TwigPHPStanCompiler\NodeAnalyzer\MissingTwigTemplateRenderVariableResolver;
-use Symplify\PHPStanRules\Rules\AbstractSymplifyRule;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
+ * @implements Rule<MethodCall>
  * @api
  * @see \Reveal\RevealTwig\Tests\Rules\NoTwigMissingVariableRule\NoTwigMissingVariableRuleTest
  */
-final class NoTwigMissingVariableRule extends AbstractSymplifyRule
+final class NoTwigMissingVariableRule implements Rule
 {
     /**
      * @var string
@@ -31,18 +32,18 @@ final class NoTwigMissingVariableRule extends AbstractSymplifyRule
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return class-string<Node>
      */
-    public function getNodeTypes(): array
+    public function getNodeType(): string
     {
-        return [MethodCall::class];
+        return MethodCall::class;
     }
 
     /**
      * @param MethodCall $node
      * @return string[]
      */
-    public function process(Node $node, Scope $scope): array
+    public function processNode(Node $node, Scope $scope): array
     {
         $renderTemplatesWithParameters = $this->symfonyRenderWithParametersMatcher->matchSymfonyRender($node, $scope);
 

--- a/packages/reveal-twig/src/Rules/NoTwigRenderUnusedVariableRule.php
+++ b/packages/reveal-twig/src/Rules/NoTwigRenderUnusedVariableRule.php
@@ -7,16 +7,17 @@ namespace Reveal\RevealTwig\Rules;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
 use Reveal\RevealTwig\NodeAnalyzer\SymfonyRenderWithParametersMatcher;
 use Reveal\TwigPHPStanCompiler\NodeAnalyzer\UnusedTwigTemplateVariableAnalyzer;
-use Symplify\PHPStanRules\Rules\AbstractSymplifyRule;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
+ * @implements Rule<MethodCall>
  * @see \Reveal\RevealTwig\Tests\Rules\NoTwigRenderUnusedVariableRule\NoTwigRenderUnusedVariableRuleTest
  */
-final class NoTwigRenderUnusedVariableRule extends AbstractSymplifyRule
+final class NoTwigRenderUnusedVariableRule implements Rule
 {
     /**
      * @var string
@@ -30,18 +31,18 @@ final class NoTwigRenderUnusedVariableRule extends AbstractSymplifyRule
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return class-string<Node>
      */
-    public function getNodeTypes(): array
+    public function getNodeType(): string
     {
-        return [MethodCall::class];
+        return MethodCall::class;
     }
 
     /**
      * @param MethodCall $node
      * @return string[]
      */
-    public function process(Node $node, Scope $scope): array
+    public function processNode(Node $node, Scope $scope): array
     {
         $renderTemplatesWithParameters = $this->symfonyRenderWithParametersMatcher->matchTwigRender($node, $scope);
 

--- a/packages/reveal-twig/src/Rules/TwigCompleteCheckRule.php
+++ b/packages/reveal-twig/src/Rules/TwigCompleteCheckRule.php
@@ -17,15 +17,15 @@ use Reveal\TemplatePHPStanCompiler\Reporting\TemplateErrorsFactory;
 use Reveal\TemplatePHPStanCompiler\TypeAnalyzer\TemplateVariableTypesResolver;
 use Reveal\TemplatePHPStanCompiler\ValueObject\VariableAndType;
 use Reveal\TwigPHPStanCompiler\TwigToPhpCompiler;
-use Symplify\PHPStanRules\Rules\AbstractSymplifyRule;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Symplify\SmartFileSystem\SmartFileSystem;
 
 /**
+ * @implements Rule<MethodCall>
  * @see \Reveal\RevealTwig\Tests\Rules\TwigCompleteCheckRule\TwigCompleteCheckRuleTest
  */
-final class TwigCompleteCheckRule extends AbstractSymplifyRule
+final class TwigCompleteCheckRule implements Rule
 {
     /**
      * @var string
@@ -65,18 +65,18 @@ final class TwigCompleteCheckRule extends AbstractSymplifyRule
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return class-string<Node>
      */
-    public function getNodeTypes(): array
+    public function getNodeType(): string
     {
-        return [MethodCall::class];
+        return MethodCall::class;
     }
 
     /**
      * @param MethodCall $node
      * @return array<string|RuleError>
      */
-    public function process(Node $node, Scope $scope): array
+    public function processNode(Node $node, Scope $scope): array
     {
         // 1. find twig template file path with array
         $renderTemplatesWithParameters = $this->symfonyRenderWithParametersMatcher->matchTwigRender($node, $scope);


### PR DESCRIPTION
Ok, that was quicker than I expected 🙂 

Solves the same problem as #6, but through refactoring the twig rules instead of requiring the heavy dependency.