### PR TITLE
[RevealLatte] Added CallStaticMethodsRule to tests

### DIFF
--- a/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/LatteCompleteCheckRuleTest.php
+++ b/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/LatteCompleteCheckRuleTest.php
@@ -63,6 +63,8 @@ final class LatteCompleteCheckRuleTest extends AbstractServiceAwareRuleTestCase
         yield [__DIR__ . '/Fixture/MultiActionsAndRendersPresenter.php', $multiActionsPresenterErrors];
 
         $errorMessages = [
+            ['Static method Latte\Runtime\Filters::date() invoked with 3 parameters, 1-2 required.', 23],
+            ['Parameter #2 $format of static method Latte\Runtime\Filters::date() expects string|null, int given.', 23],
             ['Variable $nonExistingVariable might not be defined.', 23],
             ['Call to an undefined method Nette\Security\User::nonExistingMethod().', 23],
             [sprintf('Call to an undefined method %s::getTitle().', ExampleModel::class), 23],
@@ -102,6 +104,8 @@ final class LatteCompleteCheckRuleTest extends AbstractServiceAwareRuleTestCase
     private function createSharedErrorMessages(int $phpLine): array
     {
         return [
+            ['Static method Latte\Runtime\Filters::date() invoked with 3 parameters, 1-2 required.', $phpLine],
+            ['Parameter #2 $format of static method Latte\Runtime\Filters::date() expects string|null, int given.', $phpLine],
             ['Variable $nonExistingVariable might not be defined.', $phpLine],
             ['Call to an undefined method Nette\Security\User::nonExistingMethod().', $phpLine],
             [sprintf('Call to an undefined method %s::getTitle().', ExampleModel::class), $phpLine],

--- a/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/config/configured_rule.neon
+++ b/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/config/configured_rule.neon
@@ -23,6 +23,10 @@ services:
         tags: [phpstan.rules.rule]
 
     -
+        class: PHPStan\Rules\Methods\CallStaticMethodsRule
+        tags: [phpstan.rules.rule]
+
+    -
         class: PHPStan\Rules\Variables\DefinedVariableRule
         tags: [phpstan.rules.rule]
         arguments:


### PR DESCRIPTION
I missed this already in https://github.com/symplify/symplify/pull/3661/files/70e4d4995136a1ebd329d90bc58547cd7e0769af#r722065671 finally I found solution