### PR TITLE
Special filters

### DIFF
--- a/packages/latte-phpstan-compiler/src/LatteVariableCollector/DefaultTemplateVariables.php
+++ b/packages/latte-phpstan-compiler/src/LatteVariableCollector/DefaultTemplateVariables.php
@@ -22,6 +22,7 @@ final class DefaultTemplateVariables implements LatteVariableCollectorInterface
         $variablesAndTypes = [];
         $variablesAndTypes[] = new VariableAndType('baseUrl', new StringType());
         $variablesAndTypes[] = new VariableAndType('basePath', new StringType());
+        $variablesAndTypes[] = new VariableAndType('ʟ_fi', new ObjectType('Latte\Runtime\FilterInfo'));
 
         // nette\security bridge
         $variablesAndTypes[] = new VariableAndType('user', new ObjectType('Nette\Security\User'));

--- a/packages/latte-phpstan-compiler/src/PhpParser/NodeVisitor/MagicFilterToExplicitCallNodeVisitor.php
+++ b/packages/latte-phpstan-compiler/src/PhpParser/NodeVisitor/MagicFilterToExplicitCallNodeVisitor.php
@@ -6,6 +6,7 @@ namespace Reveal\LattePHPStanCompiler\PhpParser\NodeVisitor;
 
 use Nette\Utils\Strings;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
@@ -64,11 +65,20 @@ final class MagicFilterToExplicitCallNodeVisitor extends NodeVisitorAbstract imp
 
         $callReference = $this->filterMatcher->match($filterName);
 
+        $args = $node->args;
+
+        // Add FilterInfo for special filters
+        if (in_array($filterName, ['striphtml', 'striptags', 'strip', 'indent', 'repeat', 'replace', 'trim'], true)) {
+            $args = array_merge([
+                new Arg(new Variable('ʟ_fi')),
+            ], $args);
+        }
+
         if ($callReference instanceof StaticCallReference) {
             return new StaticCall(
                 new FullyQualified($callReference->getClass()),
                 new Identifier($callReference->getMethod()),
-                $node->args
+                $args
             );
         }
 
@@ -78,12 +88,12 @@ final class MagicFilterToExplicitCallNodeVisitor extends NodeVisitorAbstract imp
             return new MethodCall(
                 new Variable($variableName),
                 new Identifier($callReference->getMethod()),
-                $node->args
+                $args
             );
         }
 
         if ($callReference instanceof FunctionCallReference) {
-            return new FuncCall(new FullyQualified($callReference->getFunction()), $node->args);
+            return new FuncCall(new FullyQualified($callReference->getFunction()), $args);
         }
 
         return null;

--- a/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/Fixture/SpecialFilters.php
+++ b/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/Fixture/SpecialFilters.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Reveal\RevealLatte\Tests\Rules\LatteCompleteCheckRule\Fixture;
 
 use Nette\Application\UI\Control;
-use Nette\Application\UI\Form;
 
 final class SpecialFilters extends Control
 {

--- a/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/Fixture/SpecialFilters.php
+++ b/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/Fixture/SpecialFilters.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reveal\RevealLatte\Tests\Rules\LatteCompleteCheckRule\Fixture;
+
+use Nette\Application\UI\Control;
+use Nette\Application\UI\Form;
+
+final class SpecialFilters extends Control
+{
+    public function render(): void
+    {
+        $this->template->someString = 'foo bar';
+        $this->template->setFile(__DIR__ . '/../Source/SpecialFilters.latte');
+        $this->template->render();
+    }
+}

--- a/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/LatteCompleteCheckRuleTest.php
+++ b/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/LatteCompleteCheckRuleTest.php
@@ -91,6 +91,8 @@ final class LatteCompleteCheckRuleTest extends AbstractServiceAwareRuleTestCase
             ],
         ];
         yield [__DIR__ . '/Fixture/ControlWithHandle.php', $errorMessages];
+
+        yield [__DIR__ . '/Fixture/SpecialFilters.php', []];
     }
 
     protected function getRule(): Rule

--- a/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/Source/SpecialFilters.latte
+++ b/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/Source/SpecialFilters.latte
@@ -1,0 +1,11 @@
+<div class="output">
+    <p>{$someString|stripHtml}</p>
+    <p>{$someString|striphtml}</p>
+    <p>{$someString|stripTags}</p>
+    <p>{$someString|striptags}</p>
+    <p>{$someString|strip}</p>
+    <p>{$someString|indent}</p>
+    <p>{$someString|repeat, 10}</p>
+    <p>{$someString|replace, 'from', 'to'}</p>
+    <p>{$someString|trim, 'from', 'to'}</p>
+</div>

--- a/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/Source/SpecialFilters.latte
+++ b/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/Source/SpecialFilters.latte
@@ -7,5 +7,5 @@
     <p>{$someString|indent}</p>
     <p>{$someString|repeat, 10}</p>
     <p>{$someString|replace, 'from', 'to'}</p>
-    <p>{$someString|trim, 'from', 'to'}</p>
+    <p>{$someString|trim}</p>
 </div>


### PR DESCRIPTION
Some filters are very special - as first argument they need FilterInfo.

I've started with failing test case https://github.com/revealphp/reveal/pull/17/commits/d57c223213867874d6d0d5c8bd8bae829d35c82f

Than I've added variable $ʟ_fi and changed arguments for special filters