### PR TITLE
Check for `Latte\Engine#renderToString` support in `LatteCompleteCheckRuleTest`

### DIFF
--- a/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/Fixture/RenderUsingEngineWithArrayParams.php
+++ b/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/Fixture/RenderUsingEngineWithArrayParams.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reveal\RevealLatte\Tests\Rules\LatteCompleteCheckRule\Fixture;
+
+use Reveal\RevealLatte\Tests\Rules\LatteCompleteCheckRule\Source\ExampleModel;
+
+final class RenderUsingEngineWithArrayParams
+{
+    /**
+     * @var ExampleModel[]
+     */
+    private $listOfObjects = [];
+
+    public function doStuff(): void
+    {
+        $latte = new \Latte\Engine();
+
+        $latte->renderToString(__DIR__ . '/../Source/ExampleControl.latte', [
+            'existingVariable' => '2021-09-11',
+            'listOfObjects' => $this->listOfObjects,
+        ]);
+    }
+}

--- a/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/LatteCompleteCheckRuleTest.php
+++ b/packages/reveal-latte/tests/Rules/LatteCompleteCheckRule/LatteCompleteCheckRuleTest.php
@@ -52,6 +52,10 @@ final class LatteCompleteCheckRuleTest extends AbstractServiceAwareRuleTestCase
             __DIR__ . '/Fixture/TemplateAsVariableAndRenderToStringWithParameters.php',
             $this->createSharedErrorMessages(22),
         ];
+        yield [
+            __DIR__ . '/Fixture/RenderUsingEngineWithArrayParams.php',
+            $this->createSharedErrorMessages(20),
+        ];
 
         yield [__DIR__ . '/Fixture/OneActionPresenter.php', $this->createSharedErrorMessages(10)];
 


### PR DESCRIPTION
See #11. This PR makes `LatteCompleteCheckRuleTest` check to ensure that using `Latte\Engine#renderToString` works... specifically when passing arguments in array form. (I may open another a test for the typed object form documented [here](https://latte.nette.org/en/type-system) later, if this one gets merged.)

The test is currently failing, because using `Latte\Engine` directly to render templates is not yet checked by `reveal/reveal-latte`.